### PR TITLE
CHANGE(conscienceagent): Ensure service is started or restarted at th…

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,19 +4,17 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: repository
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: users
-    - role: namespace
-      openio_namespace_name: "{{ NS }}"
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
     - role: conscience
       openio_conscience_namespace: "{{ NS }}"
       openio_conscience_bind_address: "{{ ansible_default_ipv4.address }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,12 +46,24 @@
         {{ openio_conscienceagent_servicename }}.conf"
   register: _conscienceagent_conf
 
-- name: restart conscienceagent
+- name: "restart conscienceagent to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_conscienceagent_namespace }}-{{ openio_conscienceagent_servicename }}
+  register: _restart_conscienceagent
   when:
-    - _conscienceagent_conf.changed
+    - _conscienceagent_conf is changed
     - not openio_conscienceagent_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure conscienceagent is started"
+      command: gridinit_cmd start {{ openio_conscienceagent_namespace }}-{{ openio_conscienceagent_servicename }}
+      register: _start_conscienceagent
+      changed_when: '"Success" in _start_conscienceagent.stdout'
+      when:
+        - not openio_conscienceagent_provision_only
+        - _restart_conscienceagent is skipped
+      tags: configure
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
…e end of role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION