### PR TITLE
BUGFIX/MINOR(conscienceagent): Fix the use of tags `install` and `con…

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -19,6 +19,8 @@
       openio_conscience_namespace: "{{ NS }}"
       openio_conscience_bind_address: "{{ ansible_default_ipv4.address }}"
       openio_conscience_pools: []
+      openio_conscience_inventory_groupname: all
+      openio_conscience_multiple: false
     - role: meta
       openio_meta_namespace: "{{ NS }}"
     - role: oioproxy

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -28,7 +30,7 @@
     - path: "/var/log/oio/sds/{{ openio_conscienceagent_namespace }}/{{ openio_conscienceagent_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
-  tags: install
+  tags: configure
 
 - name: Generate configuration files
   template:
@@ -45,6 +47,7 @@
       dest: "{{ openio_conscienceagent_gridinit_dir }}/{{ openio_conscienceagent_gridinit_file_prefix }}\
         {{ openio_conscienceagent_servicename }}.conf"
   register: _conscienceagent_conf
+  tags: configure
 
 - name: "restart conscienceagent to apply the new configuration"
   shell: |


### PR DESCRIPTION
…figure`

 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION