### PR TITLE
BUMP(conscience-agent): CI - Set requirements.yml to `19.10`

### DIFF
--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,29 +1,29 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-gridinit.git
-  version: "19.04"
+  version: "19.10"
   name: gridinit
 
 - src: https://github.com/open-io/ansible-role-openio-users.git
-  version: "19.04"
+  version: "19.10"
   name: users
 
 - src: https://github.com/open-io/ansible-role-openio-namespace.git
-  version: "19.04"
+  version: "19.10"
   name: namespace
 
 - src: https://github.com/open-io/ansible-role-openio-repository.git
-  version: "19.04"
+  version: "19.10"
   name: repository
 
 - src: https://github.com/open-io/ansible-role-openio-meta.git
-  version: "19.04"
+  version: "19.10"
   name: meta
 
 - src: https://github.com/open-io/ansible-role-openio-conscience.git
-  version: "19.04"
+  version: "19.10"
   name: conscience
 
 - src: https://github.com/open-io/ansible-role-openio-oioproxy.git
-  version: "19.04"
+  version: "19.10"
   name: oioproxy
 ...


### PR DESCRIPTION
 ##### SUMMARY

In order to be able to test the roles in `19.10`, it is necessary to change the branches in this file.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION