### PR TITLE
CHANGE(conscienceagent): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An Ansible role for Conscience agent. Specifically, the responsibilities of this
 | `openio_conscienceagent_check_interval`       | `5` | Check inverval in seconds |
 | `openio_conscienceagent_check_rise`       | `1` | Number of consecutive successful checks to switch service status to up |
 | `openio_conscienceagent_check_fall`       | `2` | Number of consecutive unsuccessful checks to switch service status to down |
+| `openio_conscienceagent_package_upgrade`       | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ openio_conscienceagent_gridinit_dir: "/etc/gridinit.d/{{ openio_conscienceagent_
 openio_conscienceagent_gridinit_file_prefix: ""
 
 openio_conscienceagent_provision_only: false
+openio_conscienceagent_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_conscienceagent_check_interval: 5
 openio_conscienceagent_check_rise: 1
 openio_conscienceagent_check_fall: 2

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: installed
+    state: "{{ 'latest' if openio_conscienceagent_package_upgrade else 'present' }}"
   with_items: "{{ conscienceagent_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: installed
+    state: "{{ 'latest' if openio_conscienceagent_package_upgrade else 'present' }}"
   with_items: "{{ conscienceagent_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION