### PR TITLE
FEATURE(conscienceagent): `openio_conscienceagent_include_dir`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ openio_conscienceagent_version: 'latest'
 
 openio_conscienceagent_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
 openio_conscienceagent_gridinit_file_prefix: "{{ openio_conscienceagent_namespace }}-"
+openio_conscienceagent_include_dir: "{{ openio_conscienceagent_sysconfig_dir }}/watch"
 
 openio_conscienceagent_provision_only: "{{ openio_maintenance_mode | d(false) | bool }}"
 openio_conscienceagent_package_upgrade: "{{ openio_package_upgrade | d(false) }}"

--- a/templates/conscienceagent.yml.j2
+++ b/templates/conscienceagent.yml.j2
@@ -12,7 +12,7 @@ syslog_prefix: OIO,{{ openio_conscienceagent_namespace }},conscienceagent,{{ ope
 #
 # Include path for services conf
 # # example service is provided in service-watch.yml
-include_dir: {{ openio_conscienceagent_sysconfig_dir }}/watch
+include_dir: "{{ openio_conscienceagent_include_dir }}"
 #
 #
 # Global checks configuration


### PR DESCRIPTION
 ##### SUMMARY

Allow to configure conscienceagent include dir by setting
`openio_conscienceagent_include_dir` instead of harcoding it
to `{{ openio_conscienceagent_sysconfig_dir }}/watch`.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Comes along with https://github.com/open-io/oio-sds/pull/2060 but can be
merge without waiting for this PR to be merged.